### PR TITLE
Extra ignore issue

### DIFF
--- a/collect.go
+++ b/collect.go
@@ -268,15 +268,15 @@ func normalizeResKey(v Version) string {
 // Known Extra folder names (case-insensitive, per path segment)
 // Plex standard:  https://support.plex.tv/articles/local-files-for-trailers-and-extras/
 var extraDirNames = map[string]struct{}{
-	"extras": {}, "featurettes": {}, "interviews": {}, "shorts": {},
+	"extras": {}, "featurettes": {}, "interviews": {}, "shorts": {}, "deleted": {},
 	"deleted scenes": {}, "trailers": {}, "behind the scenes": {}, "other": {}, "scenes": {},
 }
 
 // Allowed Plex standardized tokens for filename suffix (case-insensitive)
 // Plex standard:  https://support.plex.tv/articles/local-files-for-trailers-and-extras/
 var extraTokens = map[string]struct{}{
-	"behindthescenes": {}, "deleted": {}, "featurette": {},
-	"interview": {}, "scene": {}, "short": {}, "trailer": {}, "other": {},
+	"behindthescenes": {}, "deleted": {}, "featurette": {}, "deletedscene": {}, "interviews": {},
+	"interview": {}, "scene": {}, "short": {}, "trailer": {}, "other": {}, "deletedscenes": {},
 }
 
 // isExtraPath returns true if the path is inside an Extras-like folder OR

--- a/collect.go
+++ b/collect.go
@@ -127,9 +127,22 @@ func RunCollection(ctx context.Context, pc *Client, o Options) (Output, error) {
 					}
 				}
 
-				// If ignoring extras and this version lives under Extras/Featurettes/... — drop it entirely.
+				// If ignoring extras and this version lives under Extras/Featurettes store it and skip it
 				if o.IgnoreExtras && versionIsExtra {
-					continue
+					// Record this dropped version as an ignored Extra
+					ignored = append(ignored, IgnoredItem{
+						SectionID:    sec.Key,
+						SectionTitle: sec.Title,
+						Reason:       "extra_version",
+						Item: Item{
+							RatingKey: vv.RatingKey,
+							Title:     fallback(vv.Title, v.Title),
+							Year:      vv.Year,
+							Guid:      vv.Guid,
+							Versions:  []Version{ver},
+						},
+					})
+					continue // skip adding this version to the item
 				}
 
 				itemGhosts += versionGhosts

--- a/collect_integration_test.go
+++ b/collect_integration_test.go
@@ -79,7 +79,7 @@ func TestCollectRun_WithMockPlex(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 
-	out, err := Run(context.Background(), pc, o)
+	out, err := RunCollection(context.Background(), pc, o)
 	if err != nil {
 		t.Fatalf("collect.Run error: %v", err)
 	}

--- a/extras-test.go
+++ b/extras-test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+// Test various basenames to see if they are correctly identified as extras or not.
+func TestIsExtraBasename(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// Should match (suffix tokens, any case, with/without ext, optional index)
+		{"My Movies (1993)-featurette.mkv", true},
+		{"My Movies-deleted.mkv", true},
+		{"My Movies-featurette", true},
+		{"My Movies-interview.mov", true},
+		{"My Movies-scene.mkv", true},
+		{"My Movies-short.mkv", true},
+		{"My Movies-trailer.mkv", true},
+		{"My Movies-other.mkv", true},
+		{"My Movies (1993)-featurette", true},
+		{"My Movies-TRAILER", true},
+		{"My Movies-trailer-2.mkv", true},
+		{"My Movies-trailer_02", true},
+		{"My Movies-trailer.3", true},
+		{"My Movies-TRaiLeR.mkv", true},
+
+		// Should NOT match
+		{"Some -other freakin movie.mkv", false}, // extra words after "-other"
+		{"My Movies trailer.mkv", false},         // no hyphen before token
+		{"My Movies-trailerized.mkv", false},     // token embedded in a larger word
+		{"My Movies-othe.mkv", false},            // partial token
+		{"My Movies-trailer cut.mkv", false},     // extra word after token
+		{"My Movies are awesome-behindthescenes but maybe its not-trailer.mkv", true},
+	}
+
+	for _, tc := range cases {
+		if got := isExtraBasename(tc.in); got != tc.want {
+			t.Errorf("isExtraBasename(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Test various paths to see if they are correctly identified as extras or not.
+func TestIsExtraPath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// ✅ extras by folder name
+		{"/media/Movies/Extras/My.mkv", true},
+		{"/mnt/Movies/Featurettes/Foo.mp4", true},
+		{"/mnt/Movies/Behind-the-Scenes/Foo.mkv", true},
+		{"/mnt/Movies/Deleted Scenes/Foo.mkv", true},
+		{"/mnt/Movies/trailers/foo.mkv", true},
+		{"/mnt/Movies/other/foo.mkv", true},
+
+		// ✅ extras by basename suffix in a normal folder
+		{"/media/Movies/My Movies (2019)-featurette.mkv", true},
+		{"/media/Movies/My Movies-trailer", true},
+
+		// ❌ regular movies
+		{"/media/Movies/My Movie (2020).mkv", false},
+		{"/media/Movies/Some -other freakin movie.mkv", false},
+	}
+
+	for _, tc := range cases {
+		if got := isExtraPath(tc.in); got != tc.want {
+			t.Errorf("isExtraPath(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/html.go
+++ b/html.go
@@ -9,7 +9,7 @@ import (
 )
 
 // RenderHTML writes a standalone HTML report (no external assets).
-func RenderHTML(out Output, verify bool, filename string) error {
+func RenderHTML(out Output, verify bool, IgnoreExtras bool, filename string) error {
 	type pageData struct {
 		Out       Output
 		Verify    bool
@@ -123,6 +123,13 @@ hr{border:none;height:1px;background:var(--border);margin:20px 0}
         <span class="chip warn">Verification: Off (ghost counts not checked)</span>
       {{ end }}
       <span class="chip">{{ policyName .Out.Summary.DuplicatePolicy }}</span>
+     {{ if gt (len .Out.Ignored) -1 }}
+      <span class="chip">{{ if .IgnoreExtras }}Extras: Ignored{{ else }}Extras: Included{{ end }}</span>
+     {{ end }}
+      {{/* Extras flag chip (we don’t have it in Summary, so derive from data):
+            if any section/item exists we can’t tell from JSON alone; simplest is
+            to pass Options.IgnoreExtras into RenderHTML; if you prefer, modify
+            RenderHTML signature to take ignoreExtras bool as a second flag. */}}
     </div>
   </header>
 

--- a/html.go
+++ b/html.go
@@ -9,16 +9,18 @@ import (
 )
 
 // RenderHTML writes a standalone HTML report (no external assets).
-func RenderHTML(out Output, verify bool, IgnoreExtras bool, filename string) error {
+func RenderHTML(out Output, verify bool, ignoreExtras bool, filename string) error {
 	type pageData struct {
-		Out       Output
-		Verify    bool
-		Generated string
+		Out          Output
+		Verify       bool
+		IgnoreExtras bool
+		Generated    string
 	}
 	data := pageData{
-		Out:       out,
-		Verify:    verify,
-		Generated: time.Now().Format("2006-01-02 15:04:05 MST"),
+		Out:          out,
+		Verify:       verify,
+		IgnoreExtras: ignoreExtras,
+		Generated:    time.Now().Format("2006-01-02 15:04:05 MST"),
 	}
 
 	funcs := template.FuncMap{

--- a/html.go
+++ b/html.go
@@ -143,13 +143,7 @@ hr{border:none;height:1px;background:var(--border);margin:20px 0}
         <span class="chip warn">Verification: Off (ghost counts not checked)</span>
       {{ end }}
       <span class="chip">{{ policyName .Out.Summary.DuplicatePolicy }}</span>
-     {{ if gt (len .Out.Ignored) -1 }}
-      <span class="chip">Extras ignored: {{ lenIgnoredBy .Out.Ignored "extra_version" }}</span>
-     {{ end }}
-      {{/* Extras flag chip (we don’t have it in Summary, so derive from data):
-            if any section/item exists we can’t tell from JSON alone; simplest is
-            to pass Options.IgnoreExtras into RenderHTML; if you prefer, modify
-            RenderHTML signature to take ignoreExtras bool as a second flag. */}}
+      <span class="chip">{{ if .IgnoreExtras }}Extras: Ignored ({{ lenIgnoredBy .Out.Ignored "extra_version" }}){{ else }}Extras: Included{{ end }}</span>
     </div>
   </header>
 
@@ -205,7 +199,7 @@ hr{border:none;height:1px;background:var(--border);margin:20px 0}
             {{ else }}<span class="badge warn">verification off</span>{{ end }}
           </summary>
           <table>
-            <thead><tr><th>Version</th><th>Codec</th><th>Resolution</th><th>Part File</th><th>Size</th><th>Status</th></tr></thead>
+            <thead><tr><th>Version</th><th>Codec</</th><th>Resolution</th><th>Part File</th><th>Size</th><th>Status</th></tr></thead>
             <tbody>
               {{ range $v := $it.Versions }}
                 {{ range $p := $v.Parts }}
@@ -231,13 +225,14 @@ hr{border:none;height:1px;background:var(--border);margin:20px 0}
     {{ end }}
   </section>
 
-  {{ if gt (len .Out.Ignored) 0 }}
+  {{ if gt (len (filterIgnoredBy .Out.Ignored "4k+1080_pair")) 0 }}
   <section class="details" style="margin-top:22px">
     <h2>Ignored (4K+1080 Pairs)</h2>
     <div class="muted small" style="margin-bottom:8px">
       The items below were not counted as duplicates because they contain exactly one 4K (≈2160p) and one 1080p version, with no other versions.
     </div>
-    {{ range $ig := .Out.Ignored }}
+    {{ $pairs := filterIgnoredBy .Out.Ignored "4k+1080_pair" }}
+    {{ range $ig := $pairs }}
     <details>
       <summary>
         {{ $ig.Item.Title }}{{ if $ig.Item.Year }} ({{ $ig.Item.Year }}){{ end }}
@@ -268,8 +263,9 @@ hr{border:none;height:1px;background:var(--border);margin:20px 0}
     </details>
     {{ end }}
   </section>
+  {{ end }}
 
-  {{ if and .IgnoreExtras (gt (lenIgnoredBy .Out.Ignored "extra_version") 0) }}
+  {{ if and .IgnoreExtras (gt (len (filterIgnoredBy .Out.Ignored "extra_version")) 0) }}
   <section class="details" style="margin-top:22px">
     <h2>Ignored Extras</h2>
     <div class="muted small" style="margin-bottom:8px">
@@ -289,21 +285,21 @@ hr{border:none;height:1px;background:var(--border);margin:20px 0}
           {{ range $v := $ig.Item.Versions }}
             {{ range $p := $v.Parts }}
             <tr>
-             <td><code>{{ $v.Container }}</code></td>
+              <td><code>{{ $v.Container }}</code></td>
               <td><span class="muted">{{ $v.VideoCodec }}</span> / <span class="muted">{{ $v.AudioCodec }}</span></td>
               <td>{{ $v.VideoResolution }} ({{ $v.Width }}×{{ $v.Height }})</td>
               <td><code>{{ $p.File }}</code></td>
               <td>{{ bytesHuman $p.Size }}</td>
               <td>
-               {{ if $.Verify }}
+                {{ if $.Verify }}
                   {{ if $p.VerifiedOnDisk }}<span class="chip ok">Verified</span>{{ else }}<span class="chip bad">Missing/Unreachable</span>{{ end }}
-                  {{ else }}<span class="chip warn">Not checked</span>{{ end }}
+                {{ else }}<span class="chip warn">Not checked</span>{{ end }}
               </td>
             </tr>
             {{ end }}
           {{ end }}
         </tbody>
-     </table>
+      </table>
     </details>
     {{ end }}
   </section>

--- a/html_render_test.go
+++ b/html_render_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderHTML_IgnoredSectionsAppear(t *testing.T) {
+	out := Output{
+		Server: "http://localhost:32400",
+		Sections: []SectionResult{
+			{SectionID: "1", SectionTitle: "Movies", Type: "movie"},
+		},
+		Summary: Summary{
+			VerificationPerformed: true,
+			TotalLibraries:        1,
+			TotalDuplicateItems:   0,
+			TotalGhostParts:       0,
+			DuplicatePolicy:       "ignore-4k-1080",
+			Libraries: []LibrarySummary{
+				{SectionID: "1", SectionTitle: "Movies", Type: "movie"},
+			},
+		},
+		Ignored: []IgnoredItem{
+			{
+				SectionID:    "1",
+				SectionTitle: "Movies",
+				Reason:       "extra_version",
+				Item: Item{
+					Title: "Foo",
+					Year:  2020,
+					Versions: []Version{
+						{
+							Container:       "mkv",
+							VideoCodec:      "hevc",
+							AudioCodec:      "aac",
+							VideoResolution: "1080",
+							Width:           1920, Height: 1080,
+							Parts: []PartOut{{File: "/movies/Foo-trailer.mkv", Size: 1000, VerifiedOnDisk: true}},
+						},
+					},
+				},
+			},
+			{
+				SectionID:    "1",
+				SectionTitle: "Movies",
+				Reason:       "4k+1080_pair",
+				Item: Item{
+					Title: "Bar",
+					Year:  2019,
+					Versions: []Version{
+						{
+							Container:       "mkv",
+							VideoCodec:      "hevc",
+							AudioCodec:      "ac3",
+							VideoResolution: "2160",
+							Width:           3840, Height: 1600,
+							Parts: []PartOut{{File: "/movies/Bar-4k.mkv", Size: 2000, VerifiedOnDisk: true}},
+						},
+						{
+							Container:       "mkv",
+							VideoCodec:      "h264",
+							AudioCodec:      "aac",
+							VideoResolution: "1080",
+							Width:           1920, Height: 1080,
+							Parts: []PartOut{{File: "/movies/Bar-1080.mkv", Size: 1500, VerifiedOnDisk: true}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	html1 := filepath.Join(dir, "with_extras.html")
+	if err := RenderHTML(out, true, true, html1); err != nil {
+		t.Fatalf("RenderHTML with extras=true failed: %v", err)
+	}
+	b1, _ := os.ReadFile(html1)
+	s1 := string(b1)
+	if !strings.Contains(s1, "Ignored Extras") {
+		t.Errorf("expected 'Ignored Extras' section when ignoreExtras is true")
+	}
+	if !strings.Contains(s1, "Ignored (4K+1080 Pairs)") {
+		t.Errorf("expected 'Ignored (4K+1080 Pairs)' section to be present")
+	}
+
+	// When ignoreExtras=false, the extras section should be hidden
+	html2 := filepath.Join(dir, "no_extras.html")
+	if err := RenderHTML(out, true, false, html2); err != nil {
+		t.Fatalf("RenderHTML with extras=false failed: %v", err)
+	}
+	b2, _ := os.ReadFile(html2)
+	s2 := string(b2)
+	if strings.Contains(s2, "Ignored Extras") {
+		t.Errorf("did not expect 'Ignored Extras' section when ignoreExtras is false")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 go build -ldflags "-X Ver=v0.3.0" ./cmd/goPlexr
 */
-var Ver = "v0.8.3"
+var Ver = "v0.8.4"
 
 func main() {
 	o := Parse()

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 go build -ldflags "-X Ver=v0.3.0" ./cmd/goPlexr
 */
-var Ver = "v0.7.0"
+var Ver = "v0.8.0"
 
 func main() {
 	o := Parse()
@@ -62,7 +62,7 @@ func main() {
 
 	// Optional HTML report
 	if o.HTMLOut != "" {
-		if err := RenderHTML(out, o.Verify, o.HTMLOut); err != nil {
+		if err := RenderHTML(out, o.Verify, o.IgnoreExtras, o.HTMLOut); err != nil {
 			fmt.Fprintln(os.Stderr, "WARN:", "write HTML:", err)
 		} else if o.Verbose {
 			fmt.Fprintln(os.Stderr, "HTML report written to", o.HTMLOut)

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 go build -ldflags "-X Ver=v0.3.0" ./cmd/goPlexr
 */
-var Ver = "v0.8.4"
+var Ver = "v0.8.5"
 
 func main() {
 	o := Parse()

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 go build -ldflags "-X Ver=v0.3.0" ./cmd/goPlexr
 */
-var Ver = "v0.8.0"
+var Ver = "v0.8.2"
 
 func main() {
 	o := Parse()
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	// Collect duplicates
-	out, err := Run(ctx, pc, o)
+	out, err := RunCollection(ctx, pc, o)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "FATAL:", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 go build -ldflags "-X Ver=v0.3.0" ./cmd/goPlexr
 */
-var Ver = "v0.8.2"
+var Ver = "v0.8.3"
 
 func main() {
 	o := Parse()

--- a/opts.go
+++ b/opts.go
@@ -12,18 +12,19 @@ type Options struct {
 	BaseURL      string
 	Token        string
 	SectionsCSV  string
+	JSONOut      string
+	HTMLOut      string
+	DupPolicy    string
 	IncludeShows bool
 	Deep         bool
 	Pretty       bool
 	Verify       bool
 	InsecureTLS  bool
-	Timeout      time.Duration
 	Verbose      bool
-	HTMLOut      string
 	Quiet        bool
-	JSONOut      string
 	ShowVersion  bool
-	DupPolicy    string
+	IgnoreExtras bool
+	Timeout      time.Duration
 }
 
 func printUsage() {
@@ -62,6 +63,7 @@ func Parse() Options {
 	flag.BoolVar(&o.ShowVersion, "version", false, "Print version and exit")
 	flag.BoolVar(&o.ShowVersion, "v", false, "Print version and exit (alias)")
 	flag.StringVar(&o.DupPolicy, "dup-policy", "ignore-4k-1080", "Duplicate policy: 'ignore-4k-1080' (default) or 'plex' (count any multi-version)")
+	flag.BoolVar(&o.IgnoreExtras, "ignore-extras", false, "Ignore versions in Extras/Featurettes/Trailers/ or -extra... when determining duplicates")
 
 	// Support --long flags, then parse
 	normalizeDoubleDash()

--- a/scripts/nightly-plex-duper-check.sh
+++ b/scripts/nightly-plex-duper-check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Wrapper script for goPlexr to loop through plex users in the db and execute the dupe report tool
+# Wrapper script for goPlexr to loop through multiple plex users in the db and execute the dupe report tool for our group
 # This is unique to my environment BUT you might find useful to modify for your own awesomeness. YMMV. not a guarantee.
 #   Puts outputted HTML files into ${DEST} variable
 #   Expects ./goplexr binary in ${DPATH}
@@ -64,7 +64,9 @@ while IFS=$'\t' read -r alias apikey ip port poll; do
     -include-shows \
     -verify \
     -quiet \
-    -html-out "$out"
+    -ignore-extras \
+    -html-out "$out" \
+    -json-out "$ouj"
 
   printf '%s  Completed for "%s" -> %s\n' "$(now)" "$alias" "$out"
 done < <(


### PR DESCRIPTION
These changes introduce the feature for ignoring `extra` files in comparisons.

Plex can and will sometimes confuse Extra's especially if they are named out of standard and merge them in as dupes. 

This changes introduces the `-ignore-dupes` flag which will skip reporting these scenarios as real "duplicates" and then provide a card at the bottom of the html report that lists the ones it ignored.   This allows you to know there's a problem you may or may not want to fix in your server without muddying up the main report.

This flag is off by default, which means reports will look same as the did prior to this release.  This flag just makes it easier to sort those out.

It works with plex standard naming convention rules (plus a few outliers): https://support.plex.tv/articles/local-files-for-trailers-and-extras/

 - It supports extras being  `Movie Title (1900)-featurette.mkv` or in a directory such as `/featurettes`