### PR TITLE
Expanding 4k+1080p ignore

### DIFF
--- a/collect.go
+++ b/collect.go
@@ -219,24 +219,60 @@ type noSectionsErr struct{}
 
 func (*noSectionsErr) Error() string { return "no movie/show sections found" }
 
-// Only exclude when there are exactly two versions and they are:
-// one 4K (2160) + one HD (1080 or 720). Policy name kept for compatibility.
+// Exclude when there are exactly two versions and they are:
+// one 4K (2160) + one HD-ish (1080 or 720, including mislabels).
 func shouldExcludeAs4kHdPair(it Item, policy string) bool {
 	if strings.ToLower(policy) != "ignore-4k-1080" {
 		return false // 'plex' or anything else: keep Plex behavior
 	}
-	counts := map[string]int{}
-	total := 0
-	for _, v := range it.Versions {
-		k := normalizeResKey(v)
-		counts[k]++
-		total++
-	}
-	if total != 2 || counts["2160"] != 1 {
+	if len(it.Versions) != 2 {
 		return false
 	}
-	// Accept 1080 or 720 as the second version (covers mis-labeled 1080->720 cases)
-	return counts["1080"] == 1 || counts["720"] == 1
+	v1, v2 := it.Versions[0], it.Versions[1]
+	is4k1 := normalizeResKey(v1) == "2160"
+	is4k2 := normalizeResKey(v2) == "2160"
+
+	// One must be 4K, the other must be HD-ish
+	if is4k1 && isHDVersion(v2) {
+		return true
+	}
+	if is4k2 && isHDVersion(v1) {
+		return true
+	}
+	return false
+}
+
+// isHDVersion returns true for 1080/720, including common mislabels.
+// It avoids classifying typical SD (720x480, 720x576) as HD.
+func isHDVersion(v Version) bool {
+	key := normalizeResKey(v)
+	if key == "1080" || key == "720" {
+		return true
+	}
+
+	// Dimension-based fallback (handles weird labels like "sd (720×388)")
+	w, h := v.Width, v.Height
+	if w < h {
+		w, h = h, w // w = long side
+	}
+
+	// Explicitly exclude common SD DVD sizes
+	if (w == 720 && (h == 480 || h == 576)) || (h == 720 && (w == 480 || w == 576)) {
+		return false
+	}
+
+	// Clearly 1080-ish mislabels
+	if w >= 1700 || h >= 1000 {
+		return true
+	}
+
+	// 720-ish: long side >= 700 and short side >= 380
+	// (captures 720×388 / 704×396 scope-y encodes, but not tiny SD)
+	if w >= 700 && h >= 380 {
+		return true
+	}
+
+	return false
 }
 
 // Normalize resolution label to a key we can compare.

--- a/collect_test.go
+++ b/collect_test.go
@@ -49,3 +49,26 @@ func TestShouldExcludeAs4k1080Pair(t *testing.T) {
 		t.Fatalf("did not expect exclusion under 'plex' policy")
 	}
 }
+
+func TestShouldExcludeAs4kHdPair_Mislabeled720(t *testing.T) {
+	item := Item{
+		Versions: []Version{
+			{Width: 3840, Height: 1600, VideoResolution: "4k"},
+			{Width: 720, Height: 388, VideoResolution: "sd"}, // mislabel
+		},
+	}
+	if !shouldExcludeAs4kHdPair(item, "ignore-4k-1080") {
+		t.Fatalf("expected true for 4k + sd(720x388) pair")
+	}
+
+	// But 4k + 720x480 should NOT be treated as HD-ish
+	itemBad := Item{
+		Versions: []Version{
+			{Width: 3840, Height: 1600, VideoResolution: "4k"},
+			{Width: 720, Height: 480, VideoResolution: "sd"},
+		},
+	}
+	if shouldExcludeAs4kHdPair(itemBad, "ignore-4k-1080") {
+		t.Fatalf("expected false for 4k + sd(720x480)")
+	}
+}

--- a/collect_test.go
+++ b/collect_test.go
@@ -33,19 +33,19 @@ func TestShouldExcludeAs4k1080Pair(t *testing.T) {
 			{VideoResolution: "1080"},
 		},
 	}
-	if !shouldExcludeAs4k1080Pair(it, "ignore-4k-1080") {
+	if !shouldExcludeAs4kHdPair(it, "ignore-4k-1080") {
 		t.Fatalf("expected exclusion for exact 4k+1080 pair")
 	}
 
 	// if an extra version exists, do not exclude
 	it.Versions = append(it.Versions, Version{VideoResolution: "720"})
-	if shouldExcludeAs4k1080Pair(it, "ignore-4k-1080") {
+	if shouldExcludeAs4kHdPair(it, "ignore-4k-1080") {
 		t.Fatalf("did not expect exclusion when extra versions present")
 	}
 
 	// non-matching policy should not exclude
 	it.Versions = []Version{{VideoResolution: "2160"}, {VideoResolution: "1080"}}
-	if shouldExcludeAs4k1080Pair(it, "plex") {
+	if shouldExcludeAs4kHdPair(it, "plex") {
 		t.Fatalf("did not expect exclusion under 'plex' policy")
 	}
 }

--- a/html.go
+++ b/html.go
@@ -54,7 +54,7 @@ func RenderHTML(out Output, verify bool, ignoreExtras bool, filename string) err
 		"policyName": func(s string) string {
 			switch strings.ToLower(strings.TrimSpace(s)) {
 			case "ignore-4k-1080":
-				return "Policy: Ignore 4K+1080 pair"
+				return "Policy: Ignore 4K+HD pair (1080/720)"
 			default:
 				return "Policy: Plex (all multi-version)"
 			}
@@ -155,7 +155,7 @@ hr{border:none;height:1px;background:var(--border);margin:20px 0}
       <div class="card"><h3>Total Versions</h3><div style="font-size:26px;font-weight:700">{{ comma .Out.TotalVersions }}</div></div>
       <div class="card"><h3>Total Ghost Parts</h3><div style="font-size:26px;font-weight:700">{{ comma .Out.Summary.TotalGhostParts }}</div></div>
       {{ if gt .Out.Summary.VariantItemsExcluded 0 }}
-      <div class="card"><h3>4K+1080 Pairs Ignored</h3><div style="font-size:26px;font-weight:700">{{ comma .Out.Summary.VariantItemsExcluded }}</div></div>
+      <div class="card"><h3>4K+HD Pairs Ignored</h3><div style="font-size:26px;font-weight:700">{{ comma .Out.Summary.VariantItemsExcluded }}</div></div>
       {{ end }}
     </div>
 
@@ -173,7 +173,7 @@ hr{border:none;height:1px;background:var(--border);margin:20px 0}
           <div class="kv"><span>Items with ghosts</span><strong>{{ comma .ItemsWithGhosts }}</strong></div>
           <div class="kv"><span>Ghost parts</span><strong>{{ comma .GhostParts }}</strong></div>
           {{ if gt .VariantsExcluded 0 }}
-          <div class="kv"><span>4K+1080 pairs ignored</span><strong>{{ comma .VariantsExcluded }}</strong></div>
+          <div class="kv"><span>4K+HD Pairs Ignored</span><strong>{{ comma .VariantsExcluded }}</strong></div>
           {{ end }}
         </div>
       </div>
@@ -225,19 +225,19 @@ hr{border:none;height:1px;background:var(--border);margin:20px 0}
     {{ end }}
   </section>
 
-  {{ if gt (len (filterIgnoredBy .Out.Ignored "4k+1080_pair")) 0 }}
+  {{ if gt (len (filterIgnoredBy .Out.Ignored "4k+hd_pair")) 0 }}
   <section class="details" style="margin-top:22px">
-    <h2>Ignored (4K+1080 Pairs)</h2>
+    <h2>Ignored (4K+HD Pairs)</h2>
     <div class="muted small" style="margin-bottom:8px">
-      The items below were not counted as duplicates because they contain exactly one 4K (≈2160p) and one 1080p version, with no other versions.
+     Items with exactly one 4K and one HD (1080/720) version were not counted as duplicates.
     </div>
-    {{ $pairs := filterIgnoredBy .Out.Ignored "4k+1080_pair" }}
+    {{ $pairs := filterIgnoredBy .Out.Ignored "4k+hd_pair" }}
     {{ range $ig := $pairs }}
     <details>
       <summary>
-        {{ $ig.Item.Title }}{{ if $ig.Item.Year }} ({{ $ig.Item.Year }}){{ end }}
-        <span class="badge">{{ $ig.SectionTitle }}</span>
-        <span class="badge ok">Reason: 4K+1080 pair</span>
+       {{ $ig.Item.Title }}{{ if $ig.Item.Year }} ({{ $ig.Item.Year }}){{ end }}
+       <span class="badge">{{ $ig.SectionTitle }}</span>
+       <span class="badge ok">Reason: 4K+HD pair</span>
       </summary>
       <table>
         <thead><tr><th>Version</th><th>Codec</th><th>Resolution</th><th>Part File</th><th>Size</th><th>Status</th></tr></thead>

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 go build -ldflags "-X Ver=v0.3.0" ./cmd/goPlexr
 */
-var Ver = "v0.9.0"
+var Ver = "v0.9.1"
 
 func main() {
 	o := Parse()

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 go build -ldflags "-X Ver=v0.3.0" ./cmd/goPlexr
 */
-var Ver = "v0.8.5"
+var Ver = "v0.9.0"
 
 func main() {
 	o := Parse()


### PR DESCRIPTION
Modifying helpers and HTML to deal with 4K Pairs that are HD'`ish` instead of just 1080p.  This should handle all the shitbox low resolution stuff that might be a legit duplicate in libraries that are sharing multi resolution files like 4K and HD.
